### PR TITLE
Buffer `send_buf` for high throughput

### DIFF
--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -20,12 +20,14 @@
 #include "esphome/core/util.h"
 
 static const char *TAG = "streamserver";
+static const int BUF_SIZE = 128;
 
 using namespace esphome;
 
 void StreamServerComponent::setup() {
     ESP_LOGCONFIG(TAG, "Setting up stream server...");
-    this->recv_buf_.reserve(128);
+    this->recv_buf_.reserve(BUF_SIZE);
+    this->send_buf_.reserve(BUF_SIZE);
 
     this->server_ = AsyncServer(this->port_);
     this->server_.begin();
@@ -44,28 +46,74 @@ void StreamServerComponent::loop() {
 }
 
 void StreamServerComponent::cleanup() {
-    auto discriminator = [](std::unique_ptr<Client> &client) { return !client->disconnected; };
-    auto last_client = std::partition(this->clients_.begin(), this->clients_.end(), discriminator);
-    for (auto it = last_client; it != this->clients_.end(); it++)
-        ESP_LOGD(TAG, "Client %s disconnected", (*it)->identifier.c_str());
+    int count;
 
-    this->clients_.erase(last_client, this->clients_.end());
+    // find first disconnected, and then rewrite rest to keep order
+    // to keep `send_client_` be correct
+    for (count = 0; count < this->clients_.size(); ++count) {
+        if (this->clients_[count]->disconnected)
+            break;
+    }
+
+    for (int i = count; i < this->clients_.size(); ++i) {
+        auto& client = this->clients_[i];
+
+        if (!client->disconnected) {
+            this->clients_[count++].swap(client);
+            continue;
+        }
+
+        ESP_LOGD(TAG, "Client %s disconnected", this->clients_[i]->identifier.c_str());
+
+        if (this->send_client_ > i) {
+            this->send_client_--;
+        }
+    }
+
+    this->clients_.resize(count);
 }
 
 void StreamServerComponent::read() {
+    if (!this->flush()) {
+        return;
+    }
+
     int len;
     while ((len = this->stream_->available()) > 0) {
-        char buf[128];
-        size_t read = this->stream_->readBytes(buf, min(len, 128));
-        for (auto const& client : this->clients_)
-            client->tcp_client->write(buf, read);
+        this->send_buf_.resize(BUF_SIZE);
+        size_t read = this->stream_->readBytes(this->send_buf_.data(), min(len, BUF_SIZE));
+        this->send_buf_.resize(read);
+        this->send_client_ = 0;
+
+        if (!this->flush()) {
+            break;
+        }
     }
+}
+
+bool StreamServerComponent::flush() {
+    if (this->send_buf_.empty()) {
+        return true;
+    }
+
+    for ( ; this->send_client_ < this->clients_.size(); this->send_client_++) {
+        auto const& client = this->clients_[this->send_client_];
+
+        // client overflow
+        if (!client->tcp_client->write(this->send_buf_.data(), this->send_buf_.size())) {
+            return false;
+        }
+    }
+
+    this->send_buf_.resize(0);
+    this->send_client_ = 0;
+    return true;
 }
 
 void StreamServerComponent::write() {
     size_t len;
     while ((len = this->recv_buf_.size()) > 0) {
-        this->stream_->write(this->recv_buf_.data(), len);
+        len = this->stream_->write(this->recv_buf_.data(), len);
         this->recv_buf_.erase(this->recv_buf_.begin(), this->recv_buf_.begin() + len);
     }
 }

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -48,6 +48,7 @@ public:
 protected:
     void cleanup();
     void read();
+    bool flush();
     void write();
 
     struct Client {
@@ -62,6 +63,8 @@ protected:
     Stream *stream_{nullptr};
     AsyncServer server_{0};
     uint16_t port_{6638};
+    std::vector<char> send_buf_{};
+    int send_client_{0};
     std::vector<uint8_t> recv_buf_{};
     std::vector<std::unique_ptr<Client>> clients_{};
 };


### PR DESCRIPTION
Thanks for great component. It was great to find it :)

I was having a trouble when running UART on ESP8266 on 1.5M where there was clearly buffer overrun first on UART side, second on TCP side. This changes how this is implemented and makes it work pretty well by buffering UART receive, to ensure that TCP write succeeds. It is being retried on next try. This works for me well after these changes:

```yaml
uart:
  id: uart_bus
  tx_pin: GPIO15
  rx_pin: GPIO13
  baud_rate: 1500000
  rx_buffer_size: 8192
```

> Note: it would be great if this project would have license assigned (MIT preferable?). Currently, it is unclear under what conditions I'm contributing.