### PR TITLE
ESPHome ≥2021.10.0 compatibility

### DIFF
--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import re
-
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
@@ -22,12 +20,9 @@ from esphome.const import CONF_ID, CONF_PORT, __version__
 
 # ESPHome doesn't know the Stream abstraction yet, so hardcode to use a UART for now.
 
-version = sum(int(v) << s for s, v in zip([16, 8, 0], re.match(r"^(\d+)\.(\d+).(\d+)-?\w*$", __version__).groups()))
+AUTO_LOAD = ["async_tcp"]
 
-if version >= (2021 << 16 | 10 << 8 | 0):  # VERSION_CODE(2021, 10, 0)
-    AUTO_LOAD = ["async_tcp", "network"]
-
-DEPENDENCIES = ["uart"]
+DEPENDENCIES = ["uart", "network"]
 
 MULTI_CONF = True
 

--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -16,7 +16,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
-from esphome.const import CONF_ID, CONF_PORT, __version__
+from esphome.const import CONF_ID, CONF_PORT
 
 # ESPHome doesn't know the Stream abstraction yet, so hardcode to use a UART for now.
 

--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -13,12 +13,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import re
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
-from esphome.const import CONF_ID, CONF_PORT
+from esphome.const import CONF_ID, CONF_PORT, __version__
 
 # ESPHome doesn't know the Stream abstraction yet, so hardcode to use a UART for now.
+
+version = sum(int(v) << s for s, v in zip([16, 8, 0], re.match(r"^(\d+)\.(\d+).(\d+)-?\w*$", __version__).groups()))
+
+if version >= (2021 << 16 | 10 << 8 | 0):  # VERSION_CODE(2021, 10, 0)
+    AUTO_LOAD = ["async_tcp", "network"]
 
 DEPENDENCIES = ["uart"]
 

--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -18,7 +18,8 @@
 
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
-#if defined(ESPHOME_VERSION_CODE) && (ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0))
+
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
 #include "esphome/components/network/util.h"
 #endif
 
@@ -61,7 +62,7 @@ void StreamServerComponent::read() {
     while ((len = this->stream_->available()) > 0) {
         char buf[128];
         len = min(len, 128);
-#if defined(ESPHOME_VERSION_CODE) && (ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0))
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
         this->stream_->read_array(reinterpret_cast<uint8_t*>(buf), len);
 #else
         this->stream_->readBytes(buf, len);
@@ -72,7 +73,7 @@ void StreamServerComponent::read() {
 }
 
 void StreamServerComponent::write() {
-#if defined(ESPHOME_VERSION_CODE) && (ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0))
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
     this->stream_->write_array(this->recv_buf_);
     this->recv_buf_.clear();
 #else
@@ -87,7 +88,7 @@ void StreamServerComponent::write() {
 void StreamServerComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "Stream Server:");
     ESP_LOGCONFIG(TAG, "  Address: %s:%u",
-#if defined(ESPHOME_VERSION_CODE) && (ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0))
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
                   esphome::network::get_ip_address().str().c_str(),
 #else
                   network_get_address().c_str(),

--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -61,7 +61,7 @@ void StreamServerComponent::read() {
     int len;
     while ((len = this->stream_->available()) > 0) {
         char buf[128];
-        len = min(len, 128);
+        len = std::min(len, 128);
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
         this->stream_->read_array(reinterpret_cast<uint8_t*>(buf), len);
 #else

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -22,7 +22,7 @@
 
 // Provide VERSION_CODE for ESPHome versions lacking it, as existence checking doesn't work for function-like macros
 #ifndef VERSION_CODE
-#define VERSION_CODE(major, minor, patch) ((major << 16) | (minor << 8) | path)
+#define VERSION_CODE(major, minor, patch) ((major) << 16 | (minor) << 8 | (patch))
 #endif
 
 #include <memory>

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -16,13 +16,18 @@
 
 #pragma once
 
+#include "esphome/core/version.h"
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
 #include <memory>
 #include <string>
 #include <vector>
+#if defined(ESPHOME_VERSION_CODE) && (ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0))
+#include <Arduino.h>
+#else
 #include <Stream.h>
+#endif
 
 #ifdef ARDUINO_ARCH_ESP8266
 #include <ESPAsyncTCP.h>
@@ -30,10 +35,16 @@
 #include <AsyncTCP.h>
 #endif
 
+#if defined(ESPHOME_VERSION_CODE) && (ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0))
+using SSStream = esphome::uart::UARTComponent;
+#else
+using SSStream = Stream;
+#endif
+
 class StreamServerComponent : public esphome::Component {
 public:
     StreamServerComponent() = default;
-    explicit StreamServerComponent(Stream *stream) : stream_{stream} {}
+    explicit StreamServerComponent(SSStream *stream) : stream_{stream} {}
     void set_uart_parent(esphome::uart::UARTComponent *parent) { this->stream_ = parent; }
 
     void setup() override;
@@ -59,7 +70,7 @@ protected:
         bool disconnected{false};
     };
 
-    Stream *stream_{nullptr};
+    SSStream *stream_{nullptr};
     AsyncServer server_{0};
     uint16_t port_{6638};
     std::vector<uint8_t> recv_buf_{};

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -20,10 +20,15 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
+// Provide VERSION_CODE for ESPHome versions lacking it, as existence checking doesn't work for function-like macros
+#ifndef VERSION_CODE
+#define VERSION_CODE(major, minor, patch) ((major << 16) | (minor << 8) | path)
+#endif
+
 #include <memory>
 #include <string>
 #include <vector>
-#if defined(ESPHOME_VERSION_CODE) && (ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0))
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
 #include <Arduino.h>
 #else
 #include <Stream.h>
@@ -35,7 +40,7 @@
 #include <AsyncTCP.h>
 #endif
 
-#if defined(ESPHOME_VERSION_CODE) && (ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0))
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
 using SSStream = esphome::uart::UARTComponent;
 #else
 using SSStream = Stream;

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -28,15 +28,13 @@
 #include <memory>
 #include <string>
 #include <vector>
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
-#include <Arduino.h>
-#else
 #include <Stream.h>
-#endif
 
 #ifdef ARDUINO_ARCH_ESP8266
 #include <ESPAsyncTCP.h>
 #else
+// AsyncTCP.h includes parts of freertos, which require FreeRTOS.h header to be included first
+#include <freertos/FreeRTOS.h>
 #include <AsyncTCP.h>
 #endif
 


### PR DESCRIPTION
Today I updated ESPHome to 2021.10.2 which caused compilation using this library to fail. I mistakenly thought that [this is the fault](https://github.com/esphome/issues/issues/2626), however even after adding 
```yaml
esphome:
  libraries:
    - AsyncTCP
```
plenty of errors were present. Then I discovered UART component was changed.

Draft until I find replacement for `network_get_address().c_str()` which is also not found anymore, and because this is quick fix to get my Zigbee working.

Builds on https://github.com/oxan/esphome-stream-server/pull/4 , resolves https://github.com/oxan/esphome-stream-server/issues/6 .