### PR TITLE
Major update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Stream server for ESPHome
 =========================
 
-Custom component for ESPHome to expose a UART stream over WiFi or Ethernet. Can be used as a serial-to-wifi bridge as
-known from ESPLink or ser2net by using ESPHome.
+Custom component for ESPHome to expose a UART stream over WiFi or Ethernet. Provides a serial-to-wifi bridge as known
+from ESPLink or ser2net, using ESPHome.
 
 This component creates a TCP server listening on port 6638 (by default), and relays all data between the connected
 clients and the serial port. It doesn't support any control sequences, telnet options or RFC 2217, just raw data.
@@ -10,7 +10,7 @@ clients and the serial port. It doesn't support any control sequences, telnet op
 Usage
 -----
 
-Requires ESPHome v1.18.0 or higher.
+Requires ESPHome v2022.3.0 or newer.
 
 ```yaml
 external_components:
@@ -29,4 +29,24 @@ uart:
 stream_server:
    uart_id: uart_bus
    port: 1234
+```
+
+Sensors
+-------
+The server provides a binary sensor that signals whether there currently is a client connected:
+
+```yaml
+binary_sensor:
+  - platform: stream_server
+    connected:
+      name: Connected
+```
+
+It also provides a numeric sensor that indicates the number of connected clients:
+
+```yaml
+sensor:
+  - platform: stream_server
+    connection_count:
+      name: Number of connections
 ```

--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2022 Oxan van Leeuwen
+# Copyright (C) 2021-2023 Oxan van Leeuwen
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Oxan van Leeuwen
+# Copyright (C) 2021-2022 Oxan van Leeuwen
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(StreamServerComponent),
-            cv.Optional(CONF_PORT): cv.port,
+            cv.Optional(CONF_PORT, default=6638): cv.port,
             cv.Optional(CONF_BUFFER_SIZE, default=128): cv.All(
                 cv.positive_int, validate_buffer_size
             ),
@@ -52,8 +52,7 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    if CONF_PORT in config:
-        cg.add(var.set_port(config[CONF_PORT]))
+    cg.add(var.set_port(config[CONF_PORT]))
     cg.add(var.set_buffer_size(config[CONF_BUFFER_SIZE]))
 
     await cg.register_component(var, config)

--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -36,7 +36,8 @@ def validate_buffer_size(buffer_size):
     return buffer_size
 
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2022, 3, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(StreamServerComponent),
@@ -47,7 +48,7 @@ CONFIG_SCHEMA = (
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
 )
 
 

--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -26,7 +26,8 @@ DEPENDENCIES = ["uart", "network"]
 
 MULTI_CONF = True
 
-StreamServerComponent = cg.global_ns.class_("StreamServerComponent", cg.Component)
+ns = cg.global_ns
+StreamServerComponent = ns.class_("StreamServerComponent", cg.Component)
 
 
 def validate_buffer_size(buffer_size):

--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -20,7 +20,7 @@ from esphome.const import CONF_ID, CONF_PORT
 
 # ESPHome doesn't know the Stream abstraction yet, so hardcode to use a UART for now.
 
-AUTO_LOAD = ["async_tcp"]
+AUTO_LOAD = ["socket"]
 
 DEPENDENCIES = ["uart", "network"]
 

--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -29,20 +29,21 @@ MULTI_CONF = True
 StreamServerComponent = cg.global_ns.class_("StreamServerComponent", cg.Component)
 
 CONFIG_SCHEMA = (
-	cv.Schema(
-		{
-			cv.GenerateID(): cv.declare_id(StreamServerComponent),
-			cv.Optional(CONF_PORT): cv.port,
-		}
-	)
-		.extend(cv.COMPONENT_SCHEMA)
-		.extend(uart.UART_DEVICE_SCHEMA)
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(StreamServerComponent),
+            cv.Optional(CONF_PORT): cv.port,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA)
 )
 
-def to_code(config):
-	var = cg.new_Pvariable(config[CONF_ID])
-	if CONF_PORT in config:
-		cg.add(var.set_port(config[CONF_PORT]))
 
-	yield cg.register_component(var, config)
-	yield uart.register_uart_device(var, config)
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    if CONF_PORT in config:
+        cg.add(var.set_port(config[CONF_PORT]))
+
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)

--- a/components/stream_server/binary_sensor.py
+++ b/components/stream_server/binary_sensor.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2023 Oxan van Leeuwen
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+from esphome.const import (
+    DEVICE_CLASS_CONNECTIVITY,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+)
+from . import ns, StreamServerComponent
+
+CONF_CONNECTED = "connected"
+CONF_STREAM_SERVER = "stream_server"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_STREAM_SERVER): cv.use_id(StreamServerComponent),
+        cv.Required(CONF_CONNECTED): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_CONNECTIVITY,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+    }
+)
+
+
+async def to_code(config):
+    server = await cg.get_variable(config[CONF_STREAM_SERVER])
+
+    sens = await binary_sensor.new_binary_sensor(config[CONF_CONNECTED])
+    cg.add(server.set_connected_sensor(sens))

--- a/components/stream_server/sensor.py
+++ b/components/stream_server/sensor.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2023 Oxan van Leeuwen
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import (
+	ENTITY_CATEGORY_DIAGNOSTIC,
+)
+from . import ns, StreamServerComponent
+
+CONF_CONNECTION_COUNT = "connection_count"
+CONF_STREAM_SERVER = "stream_server"
+
+CONFIG_SCHEMA = cv.Schema(
+	{
+		cv.GenerateID(CONF_STREAM_SERVER): cv.use_id(StreamServerComponent),
+		cv.Required(CONF_CONNECTION_COUNT): sensor.sensor_schema(
+			accuracy_decimals=0,
+			entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+		)
+	}
+)
+
+async def to_code(config):
+	server = await cg.get_variable(config[CONF_STREAM_SERVER])
+
+	sens = await sensor.new_sensor(config[CONF_CONNECTION_COUNT])
+	cg.add(server.set_connection_count_sensor(sens))

--- a/components/stream_server/sensor.py
+++ b/components/stream_server/sensor.py
@@ -17,7 +17,8 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor
 from esphome.const import (
-	ENTITY_CATEGORY_DIAGNOSTIC,
+    STATE_CLASS_MEASUREMENT,
+    ENTITY_CATEGORY_DIAGNOSTIC,
 )
 from . import ns, StreamServerComponent
 
@@ -25,17 +26,19 @@ CONF_CONNECTION_COUNT = "connection_count"
 CONF_STREAM_SERVER = "stream_server"
 
 CONFIG_SCHEMA = cv.Schema(
-	{
-		cv.GenerateID(CONF_STREAM_SERVER): cv.use_id(StreamServerComponent),
-		cv.Required(CONF_CONNECTION_COUNT): sensor.sensor_schema(
-			accuracy_decimals=0,
-			entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-		)
-	}
+    {
+        cv.GenerateID(CONF_STREAM_SERVER): cv.use_id(StreamServerComponent),
+        cv.Required(CONF_CONNECTION_COUNT): sensor.sensor_schema(
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+    }
 )
 
-async def to_code(config):
-	server = await cg.get_variable(config[CONF_STREAM_SERVER])
 
-	sens = await sensor.new_sensor(config[CONF_CONNECTION_COUNT])
-	cg.add(server.set_connection_count_sensor(sens))
+async def to_code(config):
+    server = await cg.get_variable(config[CONF_STREAM_SERVER])
+
+    sens = await sensor.new_sensor(config[CONF_CONNECTION_COUNT])
+    cg.add(server.set_connection_count_sensor(sens))

--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -19,10 +19,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
 
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
 #include "esphome/components/network/util.h"
-#endif
-
 
 static const char *TAG = "streamserver";
 
@@ -62,37 +59,21 @@ void StreamServerComponent::read() {
     while ((len = this->stream_->available()) > 0) {
         char buf[128];
         len = std::min(len, 128);
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
         this->stream_->read_array(reinterpret_cast<uint8_t*>(buf), len);
-#else
-        this->stream_->readBytes(buf, len);
-#endif
         for (auto const& client : this->clients_)
             client->tcp_client->write(buf, len);
     }
 }
 
 void StreamServerComponent::write() {
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
     this->stream_->write_array(this->recv_buf_);
     this->recv_buf_.clear();
-#else
-    size_t len;
-    while ((len = this->recv_buf_.size()) > 0) {
-        this->stream_->write(this->recv_buf_.data(), len);
-        this->recv_buf_.erase(this->recv_buf_.begin(), this->recv_buf_.begin() + len);
-    }
-#endif
 }
 
 void StreamServerComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "Stream Server:");
     ESP_LOGCONFIG(TAG, "  Address: %s:%u",
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
                   esphome::network::get_ip_address().str().c_str(),
-#else
-                  network_get_address().c_str(),
-#endif
                   this->port_);
 }
 

--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -34,6 +34,7 @@ void StreamServerComponent::setup() {
     socklen_t bind_addrlen = socket::set_sockaddr_any(reinterpret_cast<struct sockaddr *>(&bind_addr), sizeof(bind_addr), htons(this->port_));
 
     this->socket_ = socket::socket_ip(SOCK_STREAM, PF_INET);
+    this->socket_->setblocking(false);
     this->socket_->bind(reinterpret_cast<struct sockaddr *>(&bind_addr), bind_addrlen);
     this->socket_->listen(8);
 }

--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020-2022 Oxan van Leeuwen
+/* Copyright (C) 2020-2023 Oxan van Leeuwen
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -56,6 +56,9 @@ void StreamServerComponent::dump_config() {
 #ifdef USE_BINARY_SENSOR
     LOG_BINARY_SENSOR("  ", "Connected:", this->connected_sensor_);
 #endif
+#ifdef USE_SENSOR
+    LOG_SENSOR("  ", "Connection count:", this->connection_count_sensor_);
+#endif
 }
 
 void StreamServerComponent::on_shutdown() {
@@ -67,6 +70,10 @@ void StreamServerComponent::publish_sensor() {
 #ifdef USE_BINARY_SENSOR
     if (this->connected_sensor_)
         this->connected_sensor_->publish_state(this->clients_.size() > 0);
+#endif
+#ifdef USE_SENSOR
+    if (this->connection_count_sensor_)
+        this->connection_count_sensor_->publish_state(this->clients_.size());
 #endif
 }
 

--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -52,7 +52,7 @@ void StreamServerComponent::loop() {
 
 void StreamServerComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "Stream Server:");
-    ESP_LOGCONFIG(TAG, "  Address: %s:%u", esphome::network::get_ip_address().str().c_str(), this->port_);
+    ESP_LOGCONFIG(TAG, "  Address: %s:%u", esphome::network::get_use_address().c_str(), this->port_);
 }
 
 void StreamServerComponent::on_shutdown() {

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -29,6 +29,7 @@ public:
     StreamServerComponent() = default;
     explicit StreamServerComponent(esphome::uart::UARTComponent *stream) : stream_{stream} {}
     void set_uart_parent(esphome::uart::UARTComponent *parent) { this->stream_ = parent; }
+    void set_buffer_size(size_t size) { this->buf_size_ = size; }
 
     void setup() override;
     void loop() override;
@@ -43,17 +44,29 @@ protected:
     void accept();
     void cleanup();
     void read();
+    void flush();
     void write();
 
+    size_t buf_index(size_t pos) { return pos & (this->buf_size_ - 1); }
+    /// Return the number of consecutive elements that are ahead of @p pos in memory.
+    size_t buf_ahead(size_t pos) { return (pos | (this->buf_size_ - 1)) - pos + 1; }
+
     struct Client {
-        Client(std::unique_ptr<esphome::socket::Socket> socket, std::string identifier);
+        Client(std::unique_ptr<esphome::socket::Socket> socket, std::string identifier, size_t position);
 
         std::unique_ptr<esphome::socket::Socket> socket{nullptr};
         std::string identifier{};
         bool disconnected{false};
+        size_t position{0};
     };
 
     esphome::uart::UARTComponent *stream_{nullptr};
+    size_t buf_size_;
+
+    std::unique_ptr<uint8_t[]> buf_{};
+    size_t buf_head_{0};
+    size_t buf_tail_{0};
+
     std::unique_ptr<esphome::socket::Socket> socket_{};
     uint16_t port_{6638};
     std::vector<Client> clients_{};

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -20,6 +20,10 @@
 #include "esphome/components/socket/socket.h"
 #include "esphome/components/uart/uart.h"
 
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -31,6 +35,10 @@ public:
     void set_uart_parent(esphome::uart::UARTComponent *parent) { this->stream_ = parent; }
     void set_buffer_size(size_t size) { this->buf_size_ = size; }
 
+#ifdef USE_BINARY_SENSOR
+    void set_connected_sensor(esphome::binary_sensor::BinarySensor *connected) { this->connected_sensor_ = connected; }
+#endif
+
     void setup() override;
     void loop() override;
     void dump_config() override;
@@ -41,6 +49,8 @@ public:
     void set_port(uint16_t port) { this->port_ = port; }
 
 protected:
+    void publish_sensor();
+
     void accept();
     void cleanup();
     void read();
@@ -63,6 +73,10 @@ protected:
     esphome::uart::UARTComponent *stream_{nullptr};
     uint16_t port_;
     size_t buf_size_;
+
+#ifdef USE_BINARY_SENSOR
+    esphome::binary_sensor::BinarySensor *connected_sensor_;
+#endif
 
     std::unique_ptr<uint8_t[]> buf_{};
     size_t buf_head_{0};

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -61,6 +61,7 @@ protected:
     };
 
     esphome::uart::UARTComponent *stream_{nullptr};
+    uint16_t port_;
     size_t buf_size_;
 
     std::unique_ptr<uint8_t[]> buf_{};
@@ -68,6 +69,5 @@ protected:
     size_t buf_tail_{0};
 
     std::unique_ptr<esphome::socket::Socket> socket_{};
-    uint16_t port_{6638};
     std::vector<Client> clients_{};
 };

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020-2022 Oxan van Leeuwen
+/* Copyright (C) 2020-2023 Oxan van Leeuwen
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -23,6 +23,9 @@
 #ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #endif
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
 
 #include <memory>
 #include <string>
@@ -37,6 +40,9 @@ public:
 
 #ifdef USE_BINARY_SENSOR
     void set_connected_sensor(esphome::binary_sensor::BinarySensor *connected) { this->connected_sensor_ = connected; }
+#endif
+#ifdef USE_SENSOR
+    void set_connection_count_sensor(esphome::sensor::Sensor *connection_count) { this->connection_count_sensor_ = connection_count; }
 #endif
 
     void setup() override;
@@ -76,6 +82,9 @@ protected:
 
 #ifdef USE_BINARY_SENSOR
     esphome::binary_sensor::BinarySensor *connected_sensor_;
+#endif
+#ifdef USE_SENSOR
+    esphome::sensor::Sensor *connection_count_sensor_;
 #endif
 
     std::unique_ptr<uint8_t[]> buf_{};

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -16,19 +16,12 @@
 
 #pragma once
 
-#include "esphome/core/version.h"
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
-
-// Provide VERSION_CODE for ESPHome versions lacking it, as existence checking doesn't work for function-like macros
-#ifndef VERSION_CODE
-#define VERSION_CODE(major, minor, patch) ((major) << 16 | (minor) << 8 | (patch))
-#endif
 
 #include <memory>
 #include <string>
 #include <vector>
-#include <Stream.h>
 
 #ifdef ARDUINO_ARCH_ESP8266
 #include <ESPAsyncTCP.h>
@@ -38,16 +31,10 @@
 #include <AsyncTCP.h>
 #endif
 
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
-using SSStream = esphome::uart::UARTComponent;
-#else
-using SSStream = Stream;
-#endif
-
 class StreamServerComponent : public esphome::Component {
 public:
     StreamServerComponent() = default;
-    explicit StreamServerComponent(SSStream *stream) : stream_{stream} {}
+    explicit StreamServerComponent(esphome::uart::UARTComponent *stream) : stream_{stream} {}
     void set_uart_parent(esphome::uart::UARTComponent *parent) { this->stream_ = parent; }
 
     void setup() override;
@@ -73,7 +60,7 @@ protected:
         bool disconnected{false};
     };
 
-    SSStream *stream_{nullptr};
+    esphome::uart::UARTComponent *stream_{nullptr};
     AsyncServer server_{0};
     uint16_t port_{6638};
     std::vector<uint8_t> recv_buf_{};


### PR DESCRIPTION
- Port to ESPHome's (once) new socket abstraction. This adds support for ESP-IDF, reduces code complexity and probably also increases reliability given the quality of the Arduino libraries.
- Add IPv6 support.
- Buffer incoming data from the serial port, and send it out separately to each client. Functionally this is more or less equivalent to #4, but with proper handling for multiple clients.
- Add binary sensor that indicates whether a client is connected; based on #15 but refactored to not publish a state on every `loop()`.
- Add sensor that indicates the number of connected clients.

Still needs some more testing (especially w.r.t. reliability), but should be complete code-wise.