### PR TITLE
Fix compatibility with ESPHome 2023.4

### DIFF
--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -3,6 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
+#include "esphome/core/version.h"
 
 #include "esphome/components/network/util.h"
 #include "esphome/components/socket/socket.h"
@@ -18,7 +19,11 @@ void StreamServerComponent::setup() {
     this->buf_ = std::unique_ptr<uint8_t[]>{new uint8_t[this->buf_size_]};
 
     struct sockaddr_storage bind_addr;
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2023, 4, 0)
+    socklen_t bind_addrlen = socket::set_sockaddr_any(reinterpret_cast<struct sockaddr *>(&bind_addr), sizeof(bind_addr), this->port_);
+#else
     socklen_t bind_addrlen = socket::set_sockaddr_any(reinterpret_cast<struct sockaddr *>(&bind_addr), sizeof(bind_addr), htons(this->port_));
+#endif
 
     this->socket_ = socket::socket_ip(SOCK_STREAM, PF_INET);
     this->socket_->setblocking(false);

--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -19,16 +19,45 @@ void StreamServerComponent::setup() {
     this->buf_ = std::unique_ptr<uint8_t[]>{new uint8_t[this->buf_size_]};
 
     struct sockaddr_storage bind_addr;
+
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2023, 4, 0)
     socklen_t bind_addrlen = socket::set_sockaddr_any(reinterpret_cast<struct sockaddr *>(&bind_addr), sizeof(bind_addr), this->port_);
 #else
     socklen_t bind_addrlen = socket::set_sockaddr_any(reinterpret_cast<struct sockaddr *>(&bind_addr), sizeof(bind_addr), htons(this->port_));
 #endif
+    if (bind_addrlen == 0) {
+      ESP_LOGW(TAG, "Socket unable to set sockaddr: errno %d", errno);
+      this->mark_failed();
+      return;
+    }
 
     this->socket_ = socket::socket_ip(SOCK_STREAM, PF_INET);
-    this->socket_->setblocking(false);
-    this->socket_->bind(reinterpret_cast<struct sockaddr *>(&bind_addr), bind_addrlen);
-    this->socket_->listen(8);
+    if (this->socket_ == nullptr) {
+      ESP_LOGW(TAG, "Could not create socket.");
+      this->mark_failed();
+      return;
+    }
+
+    int err = this->socket_->setblocking(false);
+    if (err != 0) {
+      ESP_LOGW(TAG, "Socket unable to set nonblocking mode: errno %d", err);
+      this->mark_failed();
+      return;
+    }
+
+    err = this->socket_->bind(reinterpret_cast<struct sockaddr *>(&bind_addr), sizeof(bind_addr));
+    if (err != 0) {
+      ESP_LOGW(TAG, "Socket unable to bind: errno %d", errno);
+      this->mark_failed();
+      return;
+    }
+
+    err = this->socket_->listen(8);
+    if (err != 0) {
+      ESP_LOGW(TAG, "Socket unable to listen: errno %d", errno);
+      this->mark_failed();
+      return;
+    }
 
     this->publish_sensor();
 }


### PR DESCRIPTION
Fixes #39. Since ESPHome 2023.4 the `stream_server` component doesn't listen on the specified port. I think this was broken by esphome/esphome#4574.
