### PR TITLE
Update stream_server.cpp

### DIFF
--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -135,7 +135,7 @@ void StreamServerComponent::flush() {
         iov[1].iov_len = this->buf_head_ - (client.position + iov[0].iov_len);
         if ((written = client.socket->writev(iov, 2)) > 0) {
             client.position += written;
-        } else if (written == 0 || errno == ECONNRESET) {
+        } else if (written == 0 || errno == ECONNRESET || errno == ENOTSOCK) {
             ESP_LOGD(TAG, "Client %s disconnected", client.identifier.c_str());
             client.disconnected = true;
             continue;  // don't consider this client when calculating the tail position
@@ -159,7 +159,7 @@ void StreamServerComponent::write() {
         while ((read = client.socket->read(&buf, sizeof(buf))) > 0)
             this->stream_->write_array(buf, read);
 
-        if (read == 0 || errno == ECONNRESET) {
+        if (read == 0 || errno == ECONNRESET || errno == ENOTSOCK) {
             ESP_LOGD(TAG, "Client %s disconnected", client.identifier.c_str());
             client.disconnected = true;
         } else if (errno == EWOULDBLOCK || errno == EAGAIN) {


### PR DESCRIPTION
Handles when a socket doesn't go away cleanly in a read or a write which would otherwise cause:

[W][stream_server:168]: Failed to read from client 192.168.199.1 with error 128!
[W][stream_server:168]: Failed to read from client 192.168.199.1 with error 128!
[E][stream_server:145]: Failed to write to client 192.168.199.1 with error 128!
[E][stream_server:145]: Failed to write to client 192.168.199.1 with error 128!

This would just go on forever because it thinks the client is still there so it tries to read/write to it.