### PR TITLE
Add a simple whitelist to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Requires ESPHome v2022.3.0 or newer.
 
 ```yaml
 external_components:
-  - source: github://oxan/esphome-stream-server
+  - source: github://wolffshots/esphome-stream-server
 
 stream_server:
 ```
@@ -80,3 +80,38 @@ stream_server:
 ```
 
 [uart-config]: https://esphome.io/components/uart.html#configuration-variables
+
+The original project from [oxan](https://github.com/oxan) has been extended to include a whitelist of IPs that the 
+server will connect to. This is not an ironclad protection against ne'er-do-wells but increases the barrier to entry for
+messing with your serial devices.
+
+One similar thing you could do is a similar change to add a "signing" field to the config so IPs need to do something extra to connect but that is out of scope for my changes.
+
+To include a whitelist you would do the following:
+```yaml
+uart:
+   id: uart_bus
+
+stream_server:
+   uart_id: uart_bus
+   port: 1234
+  whitelist:
+    - 192.168.1.100
+    - 192.168.1.102
+```
+
+If you want to debug why it wouldn't be connecting then you can enable debug logs with
+
+```yaml
+logger:
+  baud_rate: 0
+  level: debug
+```
+
+And then when a device attempts to connect and is denied you should see a log like this from the component:
+```
+[W][stream_server:090]: Client 192.168.1.105 is not whitelisted and will be disconnected.
+[D][stream_server:072]: Current whitelist is:
+[D][stream_server:074]: 	'192.168.1.101'
+[D][stream_server:074]: 	'192.168.1.102'
+```

--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
+from esphome.components.network import IPAddress
 from esphome.const import CONF_ID, CONF_PORT, CONF_BUFFER_SIZE
 
 # ESPHome doesn't know the Stream abstraction yet, so hardcode to use a UART for now.
@@ -10,6 +11,8 @@ AUTO_LOAD = ["socket"]
 DEPENDENCIES = ["uart", "network"]
 
 MULTI_CONF = True
+
+CONF_WHITELIST = "whitelist"
 
 ns = cg.global_ns
 StreamServerComponent = ns.class_("StreamServerComponent", cg.Component)
@@ -30,6 +33,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_BUFFER_SIZE, default=128): cv.All(
                 cv.positive_int, validate_buffer_size
             ),
+            cv.Optional(CONF_WHITELIST, default=[]): cv.ensure_list(cv.ipv4),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -38,9 +42,20 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
+    # Create a new instance of StreamServerComponent
     var = cg.new_Pvariable(config[CONF_ID])
+    
+    # Set port and buffer size
     cg.add(var.set_port(config[CONF_PORT]))
     cg.add(var.set_buffer_size(config[CONF_BUFFER_SIZE]))
 
+    # Register component
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+
+    # Pass the entire whitelist to the component
+    if CONF_WHITELIST in config:
+        whitelist = []
+        for ip in config[CONF_WHITELIST]:
+            whitelist.append(IPAddress(*ip.args))
+        cg.add(var.set_whitelist(whitelist))

--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -68,6 +68,13 @@ void StreamServerComponent::publish_sensor() {
 #endif
 }
 
+void StreamServerComponent::log_whitelist() {
+    ESP_LOGD(TAG, "Current whitelist is:");
+    for (const auto &ip : this->whitelist_) {
+        ESP_LOGD(TAG, "\t'%s'", ip.str().c_str());
+    }
+}
+
 void StreamServerComponent::accept() {
     struct sockaddr_storage client_addr;
     socklen_t client_addrlen = sizeof(client_addr);
@@ -77,8 +84,24 @@ void StreamServerComponent::accept() {
 
     socket->setblocking(false);
     std::string identifier = socket->getpeername();
+    esphome::network::IPAddress client_ip(identifier);
+
+    if (!is_ip_whitelisted(client_ip)) {
+        ESP_LOGW(TAG, "Client %s is not whitelisted and will be disconnected.", identifier.c_str());
+        #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
+            log_whitelist();
+        #endif
+        socket->shutdown(SHUT_RDWR); // Disconnect non-whitelisted client
+        return;
+    }
+
     this->clients_.emplace_back(std::move(socket), identifier, this->buf_head_);
-    ESP_LOGD(TAG, "New client connected from %s", identifier.c_str());
+    if( is_whitelist_empty() ){
+        ESP_LOGD(TAG, "New client connected from %s", identifier.c_str());
+    } else {
+        ESP_LOGD(TAG, "New whitelisted client connected from %s", identifier.c_str());
+    }
+    
     this->publish_sensor();
 }
 
@@ -123,7 +146,8 @@ void StreamServerComponent::flush() {
     ssize_t written;
     this->buf_tail_ = this->buf_head_;
     for (Client &client : this->clients_) {
-        if (client.disconnected || client.position == this->buf_head_)
+        esphome::network::IPAddress client_ip(client.identifier); // Should not be connected but double check whitelist
+        if (client.disconnected || client.position == this->buf_head_ || !is_ip_whitelisted(client_ip))
             continue;
 
         // Split the write into two parts: from the current position to the end of the ring buffer, and from the start
@@ -153,7 +177,8 @@ void StreamServerComponent::write() {
     uint8_t buf[128];
     ssize_t read;
     for (Client &client : this->clients_) {
-        if (client.disconnected)
+        esphome::network::IPAddress client_ip(client.identifier); // Should not be connected but double check whitelist
+        if (client.disconnected || !is_ip_whitelisted(client_ip))
             continue;
 
         while ((read = client.socket->read(&buf, sizeof(buf))) > 0)
@@ -168,6 +193,27 @@ void StreamServerComponent::write() {
             ESP_LOGW(TAG, "Failed to read from client %s with error %d!", client.identifier.c_str(), errno);
         }
     }
+}
+
+bool StreamServerComponent::is_whitelist_empty() {
+    if (this->whitelist_.empty()) {
+        return true;
+    }
+    return false;
+}
+
+bool StreamServerComponent::is_ip_whitelisted(esphome::network::IPAddress ip) {
+    // default behaviour is still allow all
+    if (this->is_whitelist_empty()) {
+        return true;
+    }
+
+    for (const auto &allowed_ip : this->whitelist_) {
+        if (ip == allowed_ip) {
+        return true;
+        }
+    }
+    return false;
 }
 
 StreamServerComponent::Client::Client(std::unique_ptr<esphome::socket::Socket> socket, std::string identifier, size_t position)

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/socket/socket.h"
 #include "esphome/components/uart/uart.h"
+#include "esphome/components/network/ip_address.h"
 
 #ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"
@@ -37,6 +38,13 @@ public:
     float get_setup_priority() const override { return esphome::setup_priority::AFTER_WIFI; }
 
     void set_port(uint16_t port) { this->port_ = port; }
+    void set_whitelist(const std::vector<esphome::network::IPAddress> &whitelist) {this->whitelist_ = whitelist;}
+
+ private:
+    std::vector<esphome::network::IPAddress> whitelist_;
+    bool is_ip_whitelisted(esphome::network::IPAddress ip);
+    bool is_whitelist_empty();
+    void log_whitelist();
 
 protected:
     void publish_sensor();


### PR DESCRIPTION
This pull request primarily introduces a new feature to the `stream_server` component, which adds support for an IP address whitelist. This enhancement allows users to specify which IP addresses are permitted to connect to the stream server, providing an additional layer of security.

Let me know if you would like this to be included and I can update the docs to be a bit more unified. All good if you'd rather close the PR though.

Key changes include:

### Documentation Updates:
* Updated `README.md` to reflect the new whitelist feature and provide configuration examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R83-R117)

### Feature Implementation:
* Added a new configuration option `CONF_WHITELIST` to the `stream_server` component in `components/stream_server/__init__.py`. [[1]](diffhunk://#diff-dad9f5b7282e112c85bb392ae0bf2c6d5329bb574ef382692da80f67a58c3ff8R15-R16) [[2]](diffhunk://#diff-dad9f5b7282e112c85bb392ae0bf2c6d5329bb574ef382692da80f67a58c3ff8R36)
* Modified the `to_code` function to handle the new whitelist configuration.

### Code Enhancements:
* Implemented the whitelist logic in `components/stream_server/stream_server.cpp`:
  - Added methods to check if an IP is whitelisted and to log the whitelist. [[1]](diffhunk://#diff-874c7de73d617c5fb88bab928abc144abe60464c8dea756fed54a34858940412R71-R77) [[2]](diffhunk://#diff-874c7de73d617c5fb88bab928abc144abe60464c8dea756fed54a34858940412R198-R218)
  - Updated the `accept`, `flush`, and `write` methods to enforce the whitelist. [[1]](diffhunk://#diff-874c7de73d617c5fb88bab928abc144abe60464c8dea756fed54a34858940412R87-R104) [[2]](diffhunk://#diff-874c7de73d617c5fb88bab928abc144abe60464c8dea756fed54a34858940412L126-R150) [[3]](diffhunk://#diff-874c7de73d617c5fb88bab928abc144abe60464c8dea756fed54a34858940412L156-R181)

### Header File Updates:
* Updated `components/stream_server/stream_server.h` to declare the new whitelist-related methods and member variables. [[1]](diffhunk://#diff-5f4062a3a8e14f1e1b8dcaf58c94ba763623bbc52b52efcecb087d3ba3b66af7R6) [[2]](diffhunk://#diff-5f4062a3a8e14f1e1b8dcaf58c94ba763623bbc52b52efcecb087d3ba3b66af7R41-R47)



sub-commits:

    feat: implement a whitelist to the config

    feat: add a whitelist to the stream server

    chore: update how we get yaml ip into cpp

    chore: add debug for whitelist contents

    chore: add log whitelist function to try format

    chore: remove c str

    chore: manually split for generated code

    chore: use ESP_LOGCONFIG for logging ip

    chore: add print to init

    chore: add esphome namespace back to ip calls

    chore: call str on ip

    chore: add dummy ip to check on log

    chore: use ipaddress in init

    doc: update readme with newer whitelist set up