### PR TITLE
Use new socket wake infrastructure to reduce latency

### DIFF
--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
 from esphome.const import CONF_ID, CONF_PORT, CONF_BUFFER_SIZE
+from esphome.util import parse_esphome_version
 
 # ESPHome doesn't know the Stream abstraction yet, so hardcode to use a UART for now.
 
@@ -45,6 +46,6 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 12, 0)
-    uart.request_wake_loop_on_rx()
-#endif
+    esphome_version = parse_esphome_version()
+    if esphome_version >= (2025, 12, 0):
+        uart.request_wake_loop_on_rx()


### PR DESCRIPTION
Enable the new low latency UART processing to allow for more real-time serial communication.

https://esphome.io/changelog/2025.12.0/#low-latency-uart-processing