### PR TITLE
Address breaking change for get_use_address in esphome from 2026.7

### DIFF
--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -48,7 +48,7 @@ void StreamServerComponent::loop() {
 
 void StreamServerComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "Stream Server:");
-#if ESP_HOME_VERSION_CODE >= VERSION_CODE(2026, 7, 0)
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 7, 0)
     char buf[network::USE_ADDRESS_BUFFER_SIZE];
     ESP_LOGCONFIG(TAG, "  Address: %s:%u", esphome::network::get_use_address_to(buf), this->port_);
 #elif ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)

--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -48,7 +48,10 @@ void StreamServerComponent::loop() {
 
 void StreamServerComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "Stream Server:");
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
+#if ESP_HOME_VERSION_CODE >= VERSION_CODE(2026, 7, 0)
+    char buf[network::USE_ADDRESS_BUFFER_SIZE];
+    ESP_LOGCONFIG(TAG, "  Address: %s:%u", esphome::network::get_use_address_to(buf), this->port_);
+#elif ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
     ESP_LOGCONFIG(TAG, "  Address: %s:%u", esphome::network::get_use_address(), this->port_);
 #else
     ESP_LOGCONFIG(TAG, "  Address: %s:%u", esphome::network::get_use_address().c_str(), this->port_);


### PR DESCRIPTION
Modify get_use_address to new get_use_address_to as per breaking change here: https://github.com/esphome/esphome/pull/17432

Tested and works on one device (ESP32).